### PR TITLE
add some initial unifi stuff

### DIFF
--- a/Pulumi.home.yaml
+++ b/Pulumi.home.yaml
@@ -55,3 +55,8 @@ config:
     secure: v1:rMP8RD5qc50FUOzN:3J+ef7lxYXOJ32S9CbFMSV/inrOIpIUNF1ALlyJCEfWDTuFEcRwrfx2xw4TO74mdBhRC+NyD9UWOue94D0FQyyUshQ96CDklZbK1MUpKbO4kroxZBPfMMzzPDu1mkxFyaw==
   plex:wasabi-url: https://s3.us-west-1.wasabisys.com
   ssm-automations:enable-automations: "true"
+  unifi:allowInsecure: "true"
+  unifi:api_url: https://192.168.1.1
+  unifi:password:
+    secure: v1:6sHbd6sF9X6P3Iq7:8iJFDFnwtrAQatuRravUuzm+mq4VGCWG8/O6Bf0Y4BE1P/Q=
+  unifi:username: pulumi-bot

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "@pulumi/pulumi": "^3.50.0",
         "@pulumi/random": "^4.8.2",
         "@pulumi/tls": "^4.6.1",
+        "@pulumiverse/unifi": "^0.0.3",
         "ip-address": "^8.1.0",
         "netmask": "^2.0.2",
         "openpgp": "~5.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   '@pulumi/pulumi': ^3.50.0
   '@pulumi/random': ^4.8.2
   '@pulumi/tls': ^4.6.1
+  '@pulumiverse/unifi': ^0.0.3
   '@types/netmask': 1.0.30
   '@types/node': 16.18.11
   ip-address: ^8.1.0
@@ -23,6 +24,7 @@ dependencies:
   '@pulumi/pulumi': 3.50.0
   '@pulumi/random': 4.8.2
   '@pulumi/tls': 4.6.1
+  '@pulumiverse/unifi': 0.0.3
   ip-address: 8.1.0
   netmask: 2.0.2
   openpgp: 5.1.0
@@ -287,6 +289,15 @@ packages:
 
   /@pulumi/tls/4.6.1:
     resolution: {integrity: sha512-XSSQy69s4FNyhfllig2tvo3p3e5MH0xvB9jm53FfbitaJm7NzJLfM/RxMEbu+Ys9CdnrTrbJLl22GmGHASCCng==}
+    requiresBuild: true
+    dependencies:
+      '@pulumi/pulumi': 3.50.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@pulumiverse/unifi/0.0.3:
+    resolution: {integrity: sha512-UI3P0h8JKVhxmAIk2ERQuwamQ5UH3ob4dK+cEOGT5cG9xbmvoFRzgkD3FhCXuv5UC/9dDwgEdVpWGFXeouFtPw==}
     requiresBuild: true
     dependencies:
       '@pulumi/pulumi': 3.50.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { SsmAutomations } from './lib/ssm-automations'
 import { Vpc } from './lib/vpc'
 import { providers } from './providers'
 import './pulumi-state'
+import './unifi-stuff'
 export { homebridge } from './homebridge-stuff'
 export { udm } from './udm-stuff'
 

--- a/src/unifi-stuff.ts
+++ b/src/unifi-stuff.ts
@@ -1,0 +1,52 @@
+import * as unifi from '@pulumiverse/unifi'
+
+const _default = new unifi.Network(
+    'default',
+    {
+        name: 'default',
+        purpose: 'corporate',
+        site: 'default',
+        igmpSnooping: true,
+        domainName: 'default.home.bennettp123.com',
+
+        subnet: '192.168.1.0/24',
+        dhcpStart: '192.168.1.6',
+        dhcpStop: '192.168.1.254',
+
+        ipv6InterfaceType: 'static',
+        ipv6StaticSubnet: '2404:bf40:e402:1::1/64',
+        ipv6RaEnable: true,
+        ipv6RaPriority: 'high',
+        ipv6RaValidLifetime: 0,
+    },
+    {
+        protect: true,
+        deleteBeforeReplace: true,
+    },
+)
+
+const dns = new unifi.Network(
+    'dns',
+    {
+        name: 'dns',
+        purpose: 'corporate',
+        site: 'default',
+        vlanId: 5,
+        igmpSnooping: true,
+
+        subnet: '192.168.5.0/24',
+        dhcpEnabled: true,
+        dhcpStart: '192.168.5.6',
+        dhcpStop: '192.168.5.254',
+
+        ipv6InterfaceType: 'static',
+        ipv6StaticSubnet: '2404:bf40:e402:5::1/64',
+        ipv6RaPriority: 'high',
+        ipv6RaValidLifetime: 0,
+        dhcpV6DnsAuto: false,
+    },
+    {
+        protect: true,
+        deleteBeforeReplace: true,
+    },
+)


### PR DESCRIPTION
Add the `default` and `dns` networks, using the [pulumi-unifi](https://github.com/pulumiverse/pulumi-unifi) provider.

Import resources using the commands below:

```bash
pulumi import unifi:index/network:Network default name=default
pulumi import unifi:index/network:Network dns name=dns
```

The main downside to this approach is that the API is available at https://192.168.1.1, which just isn't going to cut the mustard in a publicly-hosted GitHub Actions runner. Especially since changes to the gateway are likely to cut access to the gateway. Options:
* use a different project, or a different stack, and reply it locally from my laptop
* use ssh tunnelling, or ngrok, to expose the API to the actions runner