### PR TITLE
specify vpc AZs, remove tailscale routes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
             "when": "$(basename)"
         },
         "**/*.sqlite": true
-    }
+    },
+    "aws.telemetry": false
 }

--- a/src/lib/vpc.ts
+++ b/src/lib/vpc.ts
@@ -44,6 +44,11 @@ export class Vpc extends pulumi.ComponentResource {
             vpcName,
             {
                 numberOfAvailabilityZones,
+                requestedAvailabilityZones: [
+                    'ap-southeast-2a',
+                    'ap-southeast-2b',
+                    'ap-southeast-2c',
+                ],
                 numberOfNatGateways,
                 cidrBlock,
                 enableDnsSupport: true,


### PR DESCRIPTION
Tailscale routes are advertised on udm-office0 instead

The explicit VPC AZs is needed to work around an `InvalidOptInStatus` error when disabling `ap-southeast-2-per-1`:

```
An error occurred (InvalidOptInStatus) when calling the ModifyAvailabilityZoneGroup operation: Opting out of Local Zones is not currently supported. Contact AWS Support for additional assistance.
```

